### PR TITLE
Wip 0.3.0

### DIFF
--- a/docs/riverbench_schema/category.md
+++ b/docs/riverbench_schema/category.md
@@ -1,0 +1,170 @@
+# SHACL Shapes Documentation
+
+## Shape: CategoryGraphShape
+
+### NodeShape Constraints
+
+- **sh:targetNode:** `rb:Category`
+
+### Properties
+
+#### Property: (Blank Node)
+
+**Path:**
+
+- Inverse of:
+  - Predicate path:
+    - `rdf:type`
+
+^`rdf:type`
+
+**Constraints:**
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:maxCount:** "1"^^xsd:integer
+
+---
+
+## Shape: CategoryShape
+
+### NodeShape Constraints
+
+- **sh:targetNode:** `ns1:category`
+
+### Properties
+
+#### Property: (Blank Node)
+
+**Path:**
+
+- Predicate path:
+  - `rdf:type`
+
+`rdf:type`
+
+**Constraints:**
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:maxCount:** "1"^^xsd:integer
+- **sh:hasValue:** `rb:Category`
+
+#### Property: (Blank Node)
+
+**Path:**
+
+- Predicate path:
+  - `dcterms:conformsTo`
+
+`dcterms:conformsTo`
+
+**Constraints:**
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:maxCount:** "1"^^xsd:integer
+- **sh:hasValue:** `ns2:metadata`
+
+#### Property: (Blank Node)
+
+**Path:**
+
+- Predicate path:
+  - `dcterms:identifier`
+
+`dcterms:identifier`
+
+**Constraints:**
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:maxCount:** "1"^^xsd:integer
+- **sh:datatype:** `xsd:string`
+
+#### Property: (Blank Node)
+
+**Path:**
+
+- Predicate path:
+  - `dcterms:title`
+
+`dcterms:title`
+
+**Constraints:**
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:datatype:** `rdf:langString`
+- **sh:uniqueLang:** "True"^^xsd:boolean
+
+#### Property: (Blank Node)
+
+**Path:**
+
+- Predicate path:
+  - `dcterms:description`
+
+`dcterms:description`
+
+**Constraints:**
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:datatype:** `rdf:langString`
+- **sh:uniqueLang:** "True"^^xsd:boolean
+
+---
+
+
+## Original SHACL File
+
+```turtle
+@prefix : <https://w3id.org/riverbench/schema/dataset-shacl#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <http://schema.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix rb: <https://w3id.org/riverbench/schema/metadata#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix stax: <https://w3id.org/stax/ontology#> .
+@prefix spdx: <http://spdx.org/rdf/terms#> .
+@prefix void: <http://rdfs.org/ns/void#> .
+
+# Exactly one category per file
+:CategoryGraphShape
+  a sh:NodeShape ;
+  sh:targetNode rb:Category ;
+  sh:property [
+    sh:path [ sh:inversePath rdf:type ] ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+  ]
+.
+
+:CategoryShape
+    a sh:NodeShape ;
+    sh:targetNode <https://w3id.org/riverbench/temp#category> ;
+    sh:property [
+        sh:path rdf:type ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:hasValue rb:Category ;
+    ] , [
+        sh:path dcterms:conformsTo ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:hasValue <https://w3id.org/riverbench/schema/metadata> ;
+    ] , [
+        sh:path dcterms:identifier ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
+    ] , [
+        sh:path dcterms:title ;
+        sh:minCount 1 ;
+        sh:datatype rdf:langString ;
+        sh:uniqueLang true ;
+    ] , [
+        sh:path dcterms:description ;
+        sh:minCount 1 ;
+        sh:datatype rdf:langString ;
+        sh:uniqueLang true ;
+    ]
+.
+
+```

--- a/docs/riverbench_schema/category.md
+++ b/docs/riverbench_schema/category.md
@@ -19,8 +19,8 @@
 ^`rdf:type`
 
 **Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
-- **sh:maxCount:** "1"^^xsd:integer
+- **sh:minCount:** `"1"^^xsd:integer`
+- **sh:maxCount:** `"1"^^xsd:integer`
 
 ---
 
@@ -42,8 +42,8 @@
 `rdf:type`
 
 **Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
-- **sh:maxCount:** "1"^^xsd:integer
+- **sh:minCount:** `"1"^^xsd:integer`
+- **sh:maxCount:** `"1"^^xsd:integer`
 - **sh:hasValue:** `rb:Category`
 
 #### Property: (Blank Node)
@@ -56,8 +56,8 @@
 `dcterms:conformsTo`
 
 **Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
-- **sh:maxCount:** "1"^^xsd:integer
+- **sh:minCount:** `"1"^^xsd:integer`
+- **sh:maxCount:** `"1"^^xsd:integer`
 - **sh:hasValue:** `ns2:metadata`
 
 #### Property: (Blank Node)
@@ -70,8 +70,8 @@
 `dcterms:identifier`
 
 **Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
-- **sh:maxCount:** "1"^^xsd:integer
+- **sh:minCount:** `"1"^^xsd:integer`
+- **sh:maxCount:** `"1"^^xsd:integer`
 - **sh:datatype:** `xsd:string`
 
 #### Property: (Blank Node)
@@ -84,9 +84,9 @@
 `dcterms:title`
 
 **Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
+- **sh:minCount:** `"1"^^xsd:integer`
 - **sh:datatype:** `rdf:langString`
-- **sh:uniqueLang:** "True"^^xsd:boolean
+- **sh:uniqueLang:** `"True"^^xsd:boolean`
 
 #### Property: (Blank Node)
 
@@ -98,9 +98,9 @@
 `dcterms:description`
 
 **Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
+- **sh:minCount:** `"1"^^xsd:integer`
 - **sh:datatype:** `rdf:langString`
-- **sh:uniqueLang:** "True"^^xsd:boolean
+- **sh:uniqueLang:** `"True"^^xsd:boolean`
 
 ---
 

--- a/docs/riverbench_schema/dataset.md
+++ b/docs/riverbench_schema/dataset.md
@@ -1,343 +1,5 @@
 # SHACL Shapes Documentation
 
-## Shape: ProfileGraphShape
-
-### NodeShape Constraints
-
-- **sh:targetNode:** `rb:Profile`
-
-### Properties
-
-#### Property: (Blank Node)
-
-**Path:**
-
-- Inverse of:
-  - Predicate path:
-    - `rdf:type`
-
-^`rdf:type`
-
-**Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
-- **sh:maxCount:** "1"^^xsd:integer
-
----
-
-## Shape: ProfileShape
-
-### NodeShape Constraints
-
-- **sh:targetClass:** `rb:Profile`
-
-### Properties
-
-#### Property: (Blank Node)
-
-**Path:**
-
-- Predicate path:
-  - `rdf:type`
-
-`rdf:type`
-
-**Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
-- **sh:hasValue:** `dcat:DatasetSeries`
-
-#### Property: (Blank Node)
-
-**Path:**
-
-- Predicate path:
-  - `dcterms:identifier`
-
-`dcterms:identifier`
-
-**Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
-- **sh:maxCount:** "1"^^xsd:integer
-- **sh:datatype:** `xsd:string`
-
-#### Property: (Blank Node)
-
-**Path:**
-
-- Predicate path:
-  - `dcterms:title`
-
-`dcterms:title`
-
-**Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
-- **sh:datatype:** `rdf:langString`
-- **sh:uniqueLang:** "True"^^xsd:boolean
-
-#### Property: (Blank Node)
-
-**Path:**
-
-- Predicate path:
-  - `dcterms:description`
-
-`dcterms:description`
-
-**Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
-- **sh:datatype:** `rdf:langString`
-- **sh:uniqueLang:** "True"^^xsd:boolean
-
-#### Property: (Blank Node)
-
-**Path:**
-
-- Predicate path:
-  - `rb:hasDatasetShape`
-
-`rb:hasDatasetShape`
-
-**Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
-- **sh:maxCount:** "1"^^xsd:integer
-- **sh:node:** (Blank Node)
-
-#### Property: (Blank Node)
-
-**Path:**
-
-- Predicate path:
-  - `rb:hasDistributionShape`
-
-`rb:hasDistributionShape`
-
-**Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
-- **sh:maxCount:** "1"^^xsd:integer
-- **sh:nodeKind:** `sh:BlankNodeOrIRI`
-
----
-
-## Shape: TaskGraphShape
-
-### NodeShape Constraints
-
-- **sh:targetNode:** `rb:Task`
-
-### Properties
-
-#### Property: (Blank Node)
-
-**Path:**
-
-- Inverse of:
-  - Predicate path:
-    - `rdf:type`
-
-^`rdf:type`
-
-**Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
-- **sh:maxCount:** "1"^^xsd:integer
-
----
-
-## Shape: TaskShape
-
-### NodeShape Constraints
-
-- **sh:targetNode:** `ns1:task`
-
-### Properties
-
-#### Property: (Blank Node)
-
-**Path:**
-
-- Predicate path:
-  - `rdf:type`
-
-`rdf:type`
-
-**Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
-- **sh:maxCount:** "1"^^xsd:integer
-- **sh:hasValue:** `rb:Task`
-
-#### Property: (Blank Node)
-
-**Path:**
-
-- Predicate path:
-  - `dcterms:conformsTo`
-
-`dcterms:conformsTo`
-
-**Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
-- **sh:maxCount:** "1"^^xsd:integer
-- **sh:hasValue:** `ns2:metadata`
-
-#### Property: (Blank Node)
-
-**Path:**
-
-- Predicate path:
-  - `dcterms:identifier`
-
-`dcterms:identifier`
-
-**Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
-- **sh:maxCount:** "1"^^xsd:integer
-- **sh:datatype:** `xsd:string`
-
-#### Property: (Blank Node)
-
-**Path:**
-
-- Predicate path:
-  - `dcterms:title`
-
-`dcterms:title`
-
-**Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
-- **sh:datatype:** `rdf:langString`
-- **sh:uniqueLang:** "True"^^xsd:boolean
-
-#### Property: (Blank Node)
-
-**Path:**
-
-- Predicate path:
-  - `dcterms:description`
-
-`dcterms:description`
-
-**Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
-- **sh:datatype:** `rdf:langString`
-- **sh:uniqueLang:** "True"^^xsd:boolean
-
-#### Property: (Blank Node)
-
-**Path:**
-
-- Predicate path:
-  - `dcterms:creator`
-
-`dcterms:creator`
-
-**Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
-- **sh:nodeKind:** `sh:BlankNodeOrIRI`
-
----
-
-## Shape: CategoryGraphShape
-
-### NodeShape Constraints
-
-- **sh:targetNode:** `rb:Category`
-
-### Properties
-
-#### Property: (Blank Node)
-
-**Path:**
-
-- Inverse of:
-  - Predicate path:
-    - `rdf:type`
-
-^`rdf:type`
-
-**Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
-- **sh:maxCount:** "1"^^xsd:integer
-
----
-
-## Shape: CategoryShape
-
-### NodeShape Constraints
-
-- **sh:targetNode:** `ns1:category`
-
-### Properties
-
-#### Property: (Blank Node)
-
-**Path:**
-
-- Predicate path:
-  - `rdf:type`
-
-`rdf:type`
-
-**Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
-- **sh:maxCount:** "1"^^xsd:integer
-- **sh:hasValue:** `rb:Category`
-
-#### Property: (Blank Node)
-
-**Path:**
-
-- Predicate path:
-  - `dcterms:conformsTo`
-
-`dcterms:conformsTo`
-
-**Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
-- **sh:maxCount:** "1"^^xsd:integer
-- **sh:hasValue:** `ns2:metadata`
-
-#### Property: (Blank Node)
-
-**Path:**
-
-- Predicate path:
-  - `dcterms:identifier`
-
-`dcterms:identifier`
-
-**Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
-- **sh:maxCount:** "1"^^xsd:integer
-- **sh:datatype:** `xsd:string`
-
-#### Property: (Blank Node)
-
-**Path:**
-
-- Predicate path:
-  - `dcterms:title`
-
-`dcterms:title`
-
-**Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
-- **sh:datatype:** `rdf:langString`
-- **sh:uniqueLang:** "True"^^xsd:boolean
-
-#### Property: (Blank Node)
-
-**Path:**
-
-- Predicate path:
-  - `dcterms:description`
-
-`dcterms:description`
-
-**Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
-- **sh:datatype:** `rdf:langString`
-- **sh:uniqueLang:** "True"^^xsd:boolean
-
----
-
 ## Shape: DatasetGraphShape
 
 ### NodeShape Constraints
@@ -800,3 +462,303 @@
 
 ---
 
+
+## Original SHACL File
+
+```turtle
+@prefix : <https://w3id.org/riverbench/schema/dataset-shacl#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <http://schema.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix rb: <https://w3id.org/riverbench/schema/metadata#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix stax: <https://w3id.org/stax/ontology#> .
+@prefix spdx: <http://spdx.org/rdf/terms#> .
+@prefix void: <http://rdfs.org/ns/void#> .
+
+# Exactly one dataset per file
+:DatasetGraphShape
+  a sh:NodeShape ;
+  sh:targetNode rb:Dataset ;
+  sh:property [
+    sh:path [ sh:inversePath rdf:type ] ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+  ]
+.
+
+:DatasetShape
+  a sh:NodeShape ;
+  sh:targetClass rb:Dataset ;
+  sh:property
+  [
+    sh:path rdf:type ;
+    sh:minCount 1 ;
+    sh:hasValue dcat:Dataset ;
+  ] ,
+  # General metadata
+  [
+    sh:path dcterms:conformsTo ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+    sh:nodeKind sh:IRI ;
+    sh:hasValue <https://w3id.org/riverbench/schema/metadata> ;
+  ] ,
+  [
+    sh:path dcterms:identifier ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+    sh:datatype xsd:string ;
+  ] ,
+  [
+    sh:path dcterms:title ;
+    sh:minCount 1 ;
+    sh:datatype rdf:langString ;
+    sh:uniqueLang true ;
+  ] ,
+  [
+    sh:path dcterms:description ;
+    sh:minCount 1 ;
+    sh:datatype rdf:langString ;
+    sh:uniqueLang true ;
+  ] ,
+  [
+    sh:path dcterms:issued ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+    sh:datatype xsd:date ;
+  ] ,
+  # Attribution
+  [
+    sh:path dcterms:license ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+    sh:nodeKind sh:IRI ;
+    sh:pattern "^https://spdx.org/licenses/" ;
+  ] ,
+  [
+    sh:path dcterms:creator ;
+    sh:minCount 1 ;
+    sh:nodeKind sh:BlankNodeOrIRI ;
+  ] ,
+  # Topics
+  [
+    sh:path dcat:theme ;
+    sh:minCount 1 ;
+    sh:nodeKind sh:IRI ;
+    sh:pattern "^http://eurovoc.europa.eu/" ;
+    sh:node [
+      sh:property [
+        sh:path rdf:type ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:hasValue skos:Concept ;
+      ] ;
+    ] ;
+  ] ,
+  # Technical metadata
+  [
+    sh:path void:vocabulary ;
+    sh:minCount 1 ;
+    sh:nodeKind sh:IRI ;
+  ] ,
+  [
+    sh:path rb:hasStreamElementCount ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+    sh:datatype xsd:integer ;
+  ] ,
+  [
+    sh:path stax:hasStreamTypeUsage ;
+    sh:minCount 1 ;
+    sh:maxCount 2 ;
+    sh:node :StreamTypeShape ;
+  ] ,
+  [
+    sh:path rb:hasStreamElementSplit ;
+    sh:nodeKind sh:BlankNodeOrIRI ;
+    sh:node :StreamElementSplitShape ;
+  ] ,
+  # Conformance properties
+  [
+    sh:path rb:conformsToRdf11 ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+    sh:datatype xsd:boolean ;
+  ] ,
+  [
+    sh:path rb:conformsToRdfStarDraft_20211217 ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+    sh:datatype xsd:boolean ;
+  ] ,
+  [
+    sh:path rb:usesGeneralizedRdfDatasets ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+    sh:datatype xsd:boolean ;
+  ] ,
+  [
+    sh:path rb:usesGeneralizedTriples ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+    sh:datatype xsd:boolean ;
+  ] ,
+  [
+    sh:path rb:usesRdfStar ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+    sh:datatype xsd:boolean ;
+  ] ,
+  # Disallow version, modified, landingPage, inSeries, distribution
+  [
+    sh:path dcat:version ;
+    sh:maxCount 0 ;
+  ] ,
+  [
+    sh:path dcterms:modified ;
+    sh:maxCount 0 ;
+  ] ,
+  [
+    sh:path dcat:landingPage ;
+    sh:maxCount 0 ;
+  ] ,
+  [
+    sh:path dcat:inSeries ;
+    sh:maxCount 0 ;
+  ] ,
+  [
+    sh:path dcat:distribution ;
+    sh:maxCount 0 ;
+  ]
+.
+
+# Validate stream type annotations (RDF-STaX)
+:StreamTypeShape
+  a sh:NodeShape ;
+  sh:and (
+    # General conditions
+    [
+      sh:property [
+        sh:path rdf:type ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:IRI ;
+        sh:hasValue stax:RdfStreamTypeUsage ;
+      ] , [
+        sh:path stax:hasStreamType ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:IRI ;
+        sh:node [
+          a sh:NodeShape ;
+          sh:property [
+            sh:path rdf:type ;
+            sh:hasValue stax:ConcreteRdfStreamType ;
+          ]
+        ] ;
+      ]
+    ]
+    # Either flat or grouped – specific conditions
+    [
+      sh:xone (
+        :FlatStreamTypeUsageShape
+        :GroupedStreamTypeUsageShape
+      )
+    ]
+  )
+.
+
+# Flat stream type usage
+:FlatStreamTypeUsageShape
+  sh:property [
+    sh:path (
+      stax:hasStreamType
+      [ sh:oneOrMorePath skos:broader ]
+    ) ;
+    sh:minCount 1 ;
+    sh:hasValue stax:flatStream ;
+  ]
+.
+
+# Grouped stream type usage
+# The grouped stream type must be consistent with the flat stream type
+:GroupedStreamTypeUsageShape
+  sh:property [
+    sh:path (
+      stax:hasStreamType
+      [ sh:oneOrMorePath skos:broader ]
+    ) ;
+    sh:minCount 1 ;
+    sh:hasValue stax:groupedStream ;
+  ] , [
+    sh:path (
+      stax:hasStreamType
+      stax:canBeFlattenedInto
+      [ sh:inversePath stax:hasStreamType ]
+      [ sh:inversePath stax:hasStreamTypeUsage ]
+    ) ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+    sh:nodeKind sh:IRI ;
+  ]
+.
+
+# We must have exactly one flat stream type annotation
+:FlatStreamTypeShape
+  a sh:NodeShape ;
+  sh:targetNode stax:flatStream ;
+  sh:property [
+    sh:path (
+      [ sh:oneOrMorePath skos:narrower ]
+      [ sh:inversePath stax:hasStreamType ]
+      [ sh:inversePath stax:hasStreamTypeUsage ]
+    ) ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+    sh:nodeKind sh:IRI ;
+  ]
+.
+
+:StreamElementSplitShape
+  a sh:NodeShape ;
+  sh:property [
+    sh:path rdf:type ;
+    sh:in (
+      rb:TimeStreamElementSplit
+      rb:StatementCountStreamElementSplit
+      rb:TopicStreamElementSplit
+    ) ;
+  ]
+.
+
+:SubjectShapeShape
+  a sh:NodeShape ;
+  sh:targetSubjectsOf rb:hasSubjectShape ;
+  sh:property [
+    sh:path rdf:type ;
+    sh:minCount 1 ;
+    sh:hasValue rb:TopicStreamElementSplit ;
+  ] , [
+    sh:path (
+      rb:hasSubjectShape
+      [ sh:alternativePath (
+        sh:targetClass
+        sh:targetSubjectsOf
+        sh:targetObjectsOf
+        rb:targetCustom
+      ) ]
+    ) ;
+    sh:minCount 1 ;
+    sh:nodeKind sh:IRI ;
+  ]
+.
+
+```

--- a/docs/riverbench_schema/dataset.md
+++ b/docs/riverbench_schema/dataset.md
@@ -19,8 +19,8 @@
 ^`rdf:type`
 
 **Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
-- **sh:maxCount:** "1"^^xsd:integer
+- **sh:minCount:** `"1"^^xsd:integer`
+- **sh:maxCount:** `"1"^^xsd:integer`
 
 ---
 
@@ -42,7 +42,7 @@
 `rdf:type`
 
 **Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
+- **sh:minCount:** `"1"^^xsd:integer`
 - **sh:hasValue:** `dcat:Dataset`
 
 #### Property: (Blank Node)
@@ -55,8 +55,8 @@
 `dcterms:conformsTo`
 
 **Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
-- **sh:maxCount:** "1"^^xsd:integer
+- **sh:minCount:** `"1"^^xsd:integer`
+- **sh:maxCount:** `"1"^^xsd:integer`
 - **sh:nodeKind:** `sh:IRI`
 - **sh:hasValue:** `ns1:metadata`
 
@@ -70,8 +70,8 @@
 `dcterms:identifier`
 
 **Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
-- **sh:maxCount:** "1"^^xsd:integer
+- **sh:minCount:** `"1"^^xsd:integer`
+- **sh:maxCount:** `"1"^^xsd:integer`
 - **sh:datatype:** `xsd:string`
 
 #### Property: (Blank Node)
@@ -84,9 +84,9 @@
 `dcterms:title`
 
 **Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
+- **sh:minCount:** `"1"^^xsd:integer`
 - **sh:datatype:** `rdf:langString`
-- **sh:uniqueLang:** "True"^^xsd:boolean
+- **sh:uniqueLang:** `"True"^^xsd:boolean`
 
 #### Property: (Blank Node)
 
@@ -98,9 +98,9 @@
 `dcterms:description`
 
 **Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
+- **sh:minCount:** `"1"^^xsd:integer`
 - **sh:datatype:** `rdf:langString`
-- **sh:uniqueLang:** "True"^^xsd:boolean
+- **sh:uniqueLang:** `"True"^^xsd:boolean`
 
 #### Property: (Blank Node)
 
@@ -112,8 +112,8 @@
 `dcterms:issued`
 
 **Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
-- **sh:maxCount:** "1"^^xsd:integer
+- **sh:minCount:** `"1"^^xsd:integer`
+- **sh:maxCount:** `"1"^^xsd:integer`
 - **sh:datatype:** `xsd:date`
 
 #### Property: (Blank Node)
@@ -126,10 +126,10 @@
 `dcterms:license`
 
 **Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
-- **sh:maxCount:** "1"^^xsd:integer
+- **sh:minCount:** `"1"^^xsd:integer`
+- **sh:maxCount:** `"1"^^xsd:integer`
 - **sh:nodeKind:** `sh:IRI`
-- **sh:pattern:** "^https://spdx.org/licenses/"
+- **sh:pattern:** `"^https://spdx.org/licenses/"`
 
 #### Property: (Blank Node)
 
@@ -141,7 +141,7 @@
 `dcterms:creator`
 
 **Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
+- **sh:minCount:** `"1"^^xsd:integer`
 - **sh:nodeKind:** `sh:BlankNodeOrIRI`
 
 #### Property: (Blank Node)
@@ -154,9 +154,9 @@
 `dcat:theme`
 
 **Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
+- **sh:minCount:** `"1"^^xsd:integer`
 - **sh:nodeKind:** `sh:IRI`
-- **sh:pattern:** "^http://eurovoc.europa.eu/"
+- **sh:pattern:** `"^http://eurovoc.europa.eu/"`
 - **sh:node:** (Blank Node)
 
 #### Property: (Blank Node)
@@ -169,7 +169,7 @@
 `void:vocabulary`
 
 **Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
+- **sh:minCount:** `"1"^^xsd:integer`
 - **sh:nodeKind:** `sh:IRI`
 
 #### Property: (Blank Node)
@@ -182,8 +182,8 @@
 `rb:hasStreamElementCount`
 
 **Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
-- **sh:maxCount:** "1"^^xsd:integer
+- **sh:minCount:** `"1"^^xsd:integer`
+- **sh:maxCount:** `"1"^^xsd:integer`
 - **sh:datatype:** `xsd:integer`
 
 #### Property: (Blank Node)
@@ -196,8 +196,8 @@
 `stax:hasStreamTypeUsage`
 
 **Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
-- **sh:maxCount:** "2"^^xsd:integer
+- **sh:minCount:** `"1"^^xsd:integer`
+- **sh:maxCount:** `"2"^^xsd:integer`
 - **sh:node:** `StreamTypeShape`
 
 #### Property: (Blank Node)
@@ -223,8 +223,8 @@
 `rb:conformsToRdf11`
 
 **Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
-- **sh:maxCount:** "1"^^xsd:integer
+- **sh:minCount:** `"1"^^xsd:integer`
+- **sh:maxCount:** `"1"^^xsd:integer`
 - **sh:datatype:** `xsd:boolean`
 
 #### Property: (Blank Node)
@@ -237,8 +237,8 @@
 `rb:conformsToRdfStarDraft_20211217`
 
 **Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
-- **sh:maxCount:** "1"^^xsd:integer
+- **sh:minCount:** `"1"^^xsd:integer`
+- **sh:maxCount:** `"1"^^xsd:integer`
 - **sh:datatype:** `xsd:boolean`
 
 #### Property: (Blank Node)
@@ -251,8 +251,8 @@
 `rb:usesGeneralizedRdfDatasets`
 
 **Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
-- **sh:maxCount:** "1"^^xsd:integer
+- **sh:minCount:** `"1"^^xsd:integer`
+- **sh:maxCount:** `"1"^^xsd:integer`
 - **sh:datatype:** `xsd:boolean`
 
 #### Property: (Blank Node)
@@ -265,8 +265,8 @@
 `rb:usesGeneralizedTriples`
 
 **Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
-- **sh:maxCount:** "1"^^xsd:integer
+- **sh:minCount:** `"1"^^xsd:integer`
+- **sh:maxCount:** `"1"^^xsd:integer`
 - **sh:datatype:** `xsd:boolean`
 
 #### Property: (Blank Node)
@@ -279,8 +279,8 @@
 `rb:usesRdfStar`
 
 **Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
-- **sh:maxCount:** "1"^^xsd:integer
+- **sh:minCount:** `"1"^^xsd:integer`
+- **sh:maxCount:** `"1"^^xsd:integer`
 - **sh:datatype:** `xsd:boolean`
 
 #### Property: (Blank Node)
@@ -293,7 +293,7 @@
 `dcat:version`
 
 **Constraints:**
-- **sh:maxCount:** "0"^^xsd:integer
+- **sh:maxCount:** `"0"^^xsd:integer`
 
 #### Property: (Blank Node)
 
@@ -305,7 +305,7 @@
 `dcterms:modified`
 
 **Constraints:**
-- **sh:maxCount:** "0"^^xsd:integer
+- **sh:maxCount:** `"0"^^xsd:integer`
 
 #### Property: (Blank Node)
 
@@ -317,7 +317,7 @@
 `dcat:landingPage`
 
 **Constraints:**
-- **sh:maxCount:** "0"^^xsd:integer
+- **sh:maxCount:** `"0"^^xsd:integer`
 
 #### Property: (Blank Node)
 
@@ -329,7 +329,7 @@
 `dcat:inSeries`
 
 **Constraints:**
-- **sh:maxCount:** "0"^^xsd:integer
+- **sh:maxCount:** `"0"^^xsd:integer`
 
 #### Property: (Blank Node)
 
@@ -341,7 +341,7 @@
 `dcat:distribution`
 
 **Constraints:**
-- **sh:maxCount:** "0"^^xsd:integer
+- **sh:maxCount:** `"0"^^xsd:integer`
 
 ---
 
@@ -397,8 +397,8 @@
 ((`skos:narrower`)+)/(^`stax:hasStreamType`)/(^`stax:hasStreamTypeUsage`)
 
 **Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
-- **sh:maxCount:** "1"^^xsd:integer
+- **sh:minCount:** `"1"^^xsd:integer`
+- **sh:maxCount:** `"1"^^xsd:integer`
 - **sh:nodeKind:** `sh:IRI`
 
 ---
@@ -439,7 +439,7 @@
 `rdf:type`
 
 **Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
+- **sh:minCount:** `"1"^^xsd:integer`
 - **sh:hasValue:** `rb:TopicStreamElementSplit`
 
 #### Property: (Blank Node)
@@ -457,7 +457,7 @@
 `rb:hasSubjectShape`/(`sh:targetClass`|`sh:targetSubjectsOf`|`sh:targetObjectsOf`|`rb:targetCustom`)
 
 **Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
+- **sh:minCount:** `"1"^^xsd:integer`
 - **sh:nodeKind:** `sh:IRI`
 
 ---

--- a/docs/riverbench_schema/profile-collection.md
+++ b/docs/riverbench_schema/profile-collection.md
@@ -19,7 +19,7 @@
 ^`rdf:type`
 
 **Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
+- **sh:minCount:** `"1"^^xsd:integer`
 
 ---
 

--- a/docs/riverbench_schema/profile-collection.md
+++ b/docs/riverbench_schema/profile-collection.md
@@ -1,0 +1,99 @@
+# SHACL Shapes Documentation
+
+## Shape: ProfileGraphShape
+
+### NodeShape Constraints
+
+- **sh:targetNode:** `rb:Profile`
+
+### Properties
+
+#### Property: (Blank Node)
+
+**Path:**
+
+- Inverse of:
+  - Predicate path:
+    - `rdf:type`
+
+^`rdf:type`
+
+**Constraints:**
+- **sh:minCount:** "1"^^xsd:integer
+
+---
+
+## Shape: ProfileShape
+
+### NodeShape Constraints
+
+- **sh:targetClass:** `rb:Profile`
+
+### Properties
+
+#### Property: (Blank Node)
+
+**Path:**
+
+- Predicate path:
+  - `rb:isSupersetOfProfile`
+
+`rb:isSupersetOfProfile`
+
+**Constraints:**
+- **sh:nodeKind:** `sh:IRI`
+- **sh:node:** (Blank Node)
+
+---
+
+
+## Original SHACL File
+
+```turtle
+@prefix : <https://w3id.org/riverbench/schema/dataset-shacl#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <http://schema.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix rb: <https://w3id.org/riverbench/schema/metadata#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix stax: <https://w3id.org/stax/ontology#> .
+@prefix spdx: <http://spdx.org/rdf/terms#> .
+@prefix void: <http://rdfs.org/ns/void#> .
+
+# Shape file to validate entire profile collections.
+
+# At least one profile per collection
+:ProfileGraphShape
+  a sh:NodeShape ;
+  sh:targetNode rb:Profile ;
+  sh:property [
+    sh:path [ sh:inversePath rdf:type ] ;
+    sh:minCount 1 ;
+  ]
+.
+
+# Profile shape
+:ProfileShape
+    a sh:NodeShape ;
+    sh:targetClass rb:Profile ;
+    # Check if the children profiles exist
+    sh:property [
+        sh:path rb:isSupersetOfProfile ;
+        sh:nodeKind sh:IRI ;
+        sh:node [
+            sh:property [
+                sh:path rdf:type ;
+                sh:hasValue rb:Profile ;
+            ]
+        ]
+    ]
+.
+
+```

--- a/docs/riverbench_schema/profile.md
+++ b/docs/riverbench_schema/profile.md
@@ -19,8 +19,8 @@
 ^`rdf:type`
 
 **Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
-- **sh:maxCount:** "1"^^xsd:integer
+- **sh:minCount:** `"1"^^xsd:integer`
+- **sh:maxCount:** `"1"^^xsd:integer`
 
 ---
 
@@ -42,7 +42,7 @@
 `rdf:type`
 
 **Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
+- **sh:minCount:** `"1"^^xsd:integer`
 - **sh:hasValue:** `dcat:DatasetSeries`
 
 #### Property: (Blank Node)
@@ -55,8 +55,8 @@
 `dcterms:identifier`
 
 **Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
-- **sh:maxCount:** "1"^^xsd:integer
+- **sh:minCount:** `"1"^^xsd:integer`
+- **sh:maxCount:** `"1"^^xsd:integer`
 - **sh:datatype:** `xsd:string`
 
 #### Property: (Blank Node)
@@ -69,9 +69,9 @@
 `dcterms:title`
 
 **Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
+- **sh:minCount:** `"1"^^xsd:integer`
 - **sh:datatype:** `rdf:langString`
-- **sh:uniqueLang:** "True"^^xsd:boolean
+- **sh:uniqueLang:** `"True"^^xsd:boolean`
 
 #### Property: (Blank Node)
 
@@ -83,9 +83,9 @@
 `dcterms:description`
 
 **Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
+- **sh:minCount:** `"1"^^xsd:integer`
 - **sh:datatype:** `rdf:langString`
-- **sh:uniqueLang:** "True"^^xsd:boolean
+- **sh:uniqueLang:** `"True"^^xsd:boolean`
 
 #### Property: (Blank Node)
 
@@ -97,8 +97,8 @@
 `rb:hasDatasetShape`
 
 **Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
-- **sh:maxCount:** "1"^^xsd:integer
+- **sh:minCount:** `"1"^^xsd:integer`
+- **sh:maxCount:** `"1"^^xsd:integer`
 - **sh:node:** (Blank Node)
 
 #### Property: (Blank Node)
@@ -111,8 +111,8 @@
 `rb:hasDistributionShape`
 
 **Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
-- **sh:maxCount:** "1"^^xsd:integer
+- **sh:minCount:** `"1"^^xsd:integer`
+- **sh:maxCount:** `"1"^^xsd:integer`
 - **sh:nodeKind:** `sh:BlankNodeOrIRI`
 
 ---

--- a/docs/riverbench_schema/profile.md
+++ b/docs/riverbench_schema/profile.md
@@ -1,0 +1,204 @@
+# SHACL Shapes Documentation
+
+## Shape: ProfileGraphShape
+
+### NodeShape Constraints
+
+- **sh:targetNode:** `rb:Profile`
+
+### Properties
+
+#### Property: (Blank Node)
+
+**Path:**
+
+- Inverse of:
+  - Predicate path:
+    - `rdf:type`
+
+^`rdf:type`
+
+**Constraints:**
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:maxCount:** "1"^^xsd:integer
+
+---
+
+## Shape: ProfileShape
+
+### NodeShape Constraints
+
+- **sh:targetClass:** `rb:Profile`
+
+### Properties
+
+#### Property: (Blank Node)
+
+**Path:**
+
+- Predicate path:
+  - `rdf:type`
+
+`rdf:type`
+
+**Constraints:**
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:hasValue:** `dcat:DatasetSeries`
+
+#### Property: (Blank Node)
+
+**Path:**
+
+- Predicate path:
+  - `dcterms:identifier`
+
+`dcterms:identifier`
+
+**Constraints:**
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:maxCount:** "1"^^xsd:integer
+- **sh:datatype:** `xsd:string`
+
+#### Property: (Blank Node)
+
+**Path:**
+
+- Predicate path:
+  - `dcterms:title`
+
+`dcterms:title`
+
+**Constraints:**
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:datatype:** `rdf:langString`
+- **sh:uniqueLang:** "True"^^xsd:boolean
+
+#### Property: (Blank Node)
+
+**Path:**
+
+- Predicate path:
+  - `dcterms:description`
+
+`dcterms:description`
+
+**Constraints:**
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:datatype:** `rdf:langString`
+- **sh:uniqueLang:** "True"^^xsd:boolean
+
+#### Property: (Blank Node)
+
+**Path:**
+
+- Predicate path:
+  - `rb:hasDatasetShape`
+
+`rb:hasDatasetShape`
+
+**Constraints:**
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:maxCount:** "1"^^xsd:integer
+- **sh:node:** (Blank Node)
+
+#### Property: (Blank Node)
+
+**Path:**
+
+- Predicate path:
+  - `rb:hasDistributionShape`
+
+`rb:hasDistributionShape`
+
+**Constraints:**
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:maxCount:** "1"^^xsd:integer
+- **sh:nodeKind:** `sh:BlankNodeOrIRI`
+
+---
+
+
+## Original SHACL File
+
+```turtle
+@prefix : <https://w3id.org/riverbench/schema/dataset-shacl#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <http://schema.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix rb: <https://w3id.org/riverbench/schema/metadata#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix stax: <https://w3id.org/stax/ontology#> .
+@prefix spdx: <http://spdx.org/rdf/terms#> .
+@prefix void: <http://rdfs.org/ns/void#> .
+
+# Shape file to validate single profile files.
+# See also profile-collection.ttl for shapes to validate profile collections,
+# i.e., all profiles in a benchmark category.
+
+# Exactly one profile per file
+:ProfileGraphShape
+  a sh:NodeShape ;
+  sh:targetNode rb:Profile ;
+  sh:property [
+    sh:path [ sh:inversePath rdf:type ] ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+  ]
+.
+
+# We can't easily validate this in SHACL... but the ID should match the filename
+# and URI.
+:ProfileShape
+    a sh:NodeShape ;
+    sh:targetClass rb:Profile ;
+    sh:property [
+        sh:path rdf:type ;
+        sh:minCount 1 ;
+        sh:hasValue dcat:DatasetSeries ;
+    ] , [
+        sh:path dcterms:identifier ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
+    ] , [
+        sh:path dcterms:title ;
+        sh:minCount 1 ;
+        sh:datatype rdf:langString ;
+        sh:uniqueLang true ;
+    ] , [
+        sh:path dcterms:description ;
+        sh:minCount 1 ;
+        sh:datatype rdf:langString ;
+        sh:uniqueLang true ;
+    ] , [
+        sh:path rb:hasDatasetShape ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:node [
+            sh:property [
+                sh:path sh:targetClass ;
+                sh:minCount 1 ;
+                sh:maxCount 1 ;
+                sh:hasValue rb:Dataset ;
+            ] , [
+                sh:path sh:property ;
+                sh:minCount 1 ;
+                sh:nodeKind sh:BlankNodeOrIRI ;
+            ]
+        ]
+    ] , [
+        sh:path rb:hasDistributionShape ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+    ]
+.
+
+```

--- a/docs/riverbench_schema/task.md
+++ b/docs/riverbench_schema/task.md
@@ -19,8 +19,8 @@
 ^`rdf:type`
 
 **Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
-- **sh:maxCount:** "1"^^xsd:integer
+- **sh:minCount:** `"1"^^xsd:integer`
+- **sh:maxCount:** `"1"^^xsd:integer`
 
 ---
 
@@ -42,8 +42,8 @@
 `rdf:type`
 
 **Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
-- **sh:maxCount:** "1"^^xsd:integer
+- **sh:minCount:** `"1"^^xsd:integer`
+- **sh:maxCount:** `"1"^^xsd:integer`
 - **sh:hasValue:** `rb:Task`
 
 #### Property: (Blank Node)
@@ -56,8 +56,8 @@
 `dcterms:conformsTo`
 
 **Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
-- **sh:maxCount:** "1"^^xsd:integer
+- **sh:minCount:** `"1"^^xsd:integer`
+- **sh:maxCount:** `"1"^^xsd:integer`
 - **sh:hasValue:** `ns2:metadata`
 
 #### Property: (Blank Node)
@@ -70,8 +70,8 @@
 `dcterms:identifier`
 
 **Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
-- **sh:maxCount:** "1"^^xsd:integer
+- **sh:minCount:** `"1"^^xsd:integer`
+- **sh:maxCount:** `"1"^^xsd:integer`
 - **sh:datatype:** `xsd:string`
 
 #### Property: (Blank Node)
@@ -84,9 +84,9 @@
 `dcterms:title`
 
 **Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
+- **sh:minCount:** `"1"^^xsd:integer`
 - **sh:datatype:** `rdf:langString`
-- **sh:uniqueLang:** "True"^^xsd:boolean
+- **sh:uniqueLang:** `"True"^^xsd:boolean`
 
 #### Property: (Blank Node)
 
@@ -98,9 +98,9 @@
 `dcterms:description`
 
 **Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
+- **sh:minCount:** `"1"^^xsd:integer`
 - **sh:datatype:** `rdf:langString`
-- **sh:uniqueLang:** "True"^^xsd:boolean
+- **sh:uniqueLang:** `"True"^^xsd:boolean`
 
 #### Property: (Blank Node)
 
@@ -112,7 +112,7 @@
 `dcterms:creator`
 
 **Constraints:**
-- **sh:minCount:** "1"^^xsd:integer
+- **sh:minCount:** `"1"^^xsd:integer`
 - **sh:nodeKind:** `sh:BlankNodeOrIRI`
 
 ---

--- a/docs/riverbench_schema/task.md
+++ b/docs/riverbench_schema/task.md
@@ -1,0 +1,187 @@
+# SHACL Shapes Documentation
+
+## Shape: TaskGraphShape
+
+### NodeShape Constraints
+
+- **sh:targetNode:** `rb:Task`
+
+### Properties
+
+#### Property: (Blank Node)
+
+**Path:**
+
+- Inverse of:
+  - Predicate path:
+    - `rdf:type`
+
+^`rdf:type`
+
+**Constraints:**
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:maxCount:** "1"^^xsd:integer
+
+---
+
+## Shape: TaskShape
+
+### NodeShape Constraints
+
+- **sh:targetNode:** `ns1:task`
+
+### Properties
+
+#### Property: (Blank Node)
+
+**Path:**
+
+- Predicate path:
+  - `rdf:type`
+
+`rdf:type`
+
+**Constraints:**
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:maxCount:** "1"^^xsd:integer
+- **sh:hasValue:** `rb:Task`
+
+#### Property: (Blank Node)
+
+**Path:**
+
+- Predicate path:
+  - `dcterms:conformsTo`
+
+`dcterms:conformsTo`
+
+**Constraints:**
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:maxCount:** "1"^^xsd:integer
+- **sh:hasValue:** `ns2:metadata`
+
+#### Property: (Blank Node)
+
+**Path:**
+
+- Predicate path:
+  - `dcterms:identifier`
+
+`dcterms:identifier`
+
+**Constraints:**
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:maxCount:** "1"^^xsd:integer
+- **sh:datatype:** `xsd:string`
+
+#### Property: (Blank Node)
+
+**Path:**
+
+- Predicate path:
+  - `dcterms:title`
+
+`dcterms:title`
+
+**Constraints:**
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:datatype:** `rdf:langString`
+- **sh:uniqueLang:** "True"^^xsd:boolean
+
+#### Property: (Blank Node)
+
+**Path:**
+
+- Predicate path:
+  - `dcterms:description`
+
+`dcterms:description`
+
+**Constraints:**
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:datatype:** `rdf:langString`
+- **sh:uniqueLang:** "True"^^xsd:boolean
+
+#### Property: (Blank Node)
+
+**Path:**
+
+- Predicate path:
+  - `dcterms:creator`
+
+`dcterms:creator`
+
+**Constraints:**
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:nodeKind:** `sh:BlankNodeOrIRI`
+
+---
+
+
+## Original SHACL File
+
+```turtle
+@prefix : <https://w3id.org/riverbench/schema/dataset-shacl#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <http://schema.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix rb: <https://w3id.org/riverbench/schema/metadata#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix stax: <https://w3id.org/stax/ontology#> .
+@prefix spdx: <http://spdx.org/rdf/terms#> .
+@prefix void: <http://rdfs.org/ns/void#> .
+
+# Exactly one task per file
+:TaskGraphShape
+  a sh:NodeShape ;
+  sh:targetNode rb:Task ;
+  sh:property [
+    sh:path [ sh:inversePath rdf:type ] ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+  ]
+.
+
+:TaskShape
+    a sh:NodeShape ;
+    sh:targetNode <https://w3id.org/riverbench/temp#task> ;
+    sh:property [
+        sh:path rdf:type ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:hasValue rb:Task ;
+    ] , [
+        sh:path dcterms:conformsTo ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:hasValue <https://w3id.org/riverbench/schema/metadata> ;
+    ] , [
+        sh:path dcterms:identifier ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
+    ] , [
+        sh:path dcterms:title ;
+        sh:minCount 1 ;
+        sh:datatype rdf:langString ;
+        sh:uniqueLang true ;
+    ] , [
+        sh:path dcterms:description ;
+        sh:minCount 1 ;
+        sh:datatype rdf:langString ;
+        sh:uniqueLang true ;
+    ] , [
+        sh:path dcterms:creator ;
+        sh:minCount 1 ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+    ]
+.
+
+```

--- a/docs/shapes.md
+++ b/docs/shapes.md
@@ -1,494 +1,540 @@
 # SHACL Shapes Documentation
 
-## Shape: https://w3id.org/riverbench/schema/dataset-shacl#ProfileGraphShape
+## Shape: ProfileGraphShape
 
 ### NodeShape Constraints
 
-- **sh:targetNode:** https://w3id.org/riverbench/schema/metadata#Profile
+- **sh:targetNode:** `rb:Profile`
 
 ### Properties
 
-#### Property: n919e52bf31f64cbea47ec1378b60fca8b1
+#### Property: (Blank Node)
 
-**Path:** ^http://www.w3.org/1999/02/22-rdf-syntax-ns#type
+**Path:** ^`rdf:type`
 
 **Constraints:**
-- **sh:minCount:** 1
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:maxCount:** "1"^^xsd:integer
 
 ---
 
-## Shape: https://w3id.org/riverbench/schema/dataset-shacl#ProfileShape
+## Shape: ProfileShape
 
 ### NodeShape Constraints
 
-- **sh:targetClass:** https://w3id.org/riverbench/schema/metadata#Profile
+- **sh:targetClass:** `rb:Profile`
 
 ### Properties
 
-#### Property: n919e52bf31f64cbea47ec1378b60fca8b3
+#### Property: (Blank Node)
 
-**Path:** https://w3id.org/riverbench/schema/metadata#isSupersetOfProfile
+**Path:** `rdf:type`
 
 **Constraints:**
-- **sh:nodeKind:** http://www.w3.org/ns/shacl#IRI
-- **sh:node:** {'sh:property': rdflib.term.BNode('n919e52bf31f64cbea47ec1378b60fca8b5')}
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:hasValue:** `dcat:DatasetSeries`
+
+#### Property: (Blank Node)
+
+**Path:** `dcterms:identifier`
+
+**Constraints:**
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:maxCount:** "1"^^xsd:integer
+- **sh:datatype:** `xsd:string`
+
+#### Property: (Blank Node)
+
+**Path:** `dcterms:title`
+
+**Constraints:**
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:datatype:** `rdf:langString`
+- **sh:uniqueLang:** "True"^^xsd:boolean
+
+#### Property: (Blank Node)
+
+**Path:** `dcterms:description`
+
+**Constraints:**
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:datatype:** `rdf:langString`
+- **sh:uniqueLang:** "True"^^xsd:boolean
+
+#### Property: (Blank Node)
+
+**Path:** `rb:hasDatasetShape`
+
+**Constraints:**
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:maxCount:** "1"^^xsd:integer
+- **sh:node:** (Blank Node)
+
+#### Property: (Blank Node)
+
+**Path:** `rb:hasDistributionShape`
+
+**Constraints:**
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:maxCount:** "1"^^xsd:integer
+- **sh:nodeKind:** `sh:BlankNodeOrIRI`
 
 ---
 
-## Shape: https://w3id.org/riverbench/schema/dataset-shacl#CategoryGraphShape
+## Shape: TaskGraphShape
 
 ### NodeShape Constraints
 
-- **sh:targetNode:** https://w3id.org/riverbench/schema/metadata#Category
+- **sh:targetNode:** `rb:Task`
 
 ### Properties
 
-#### Property: nd704ac798dc3413691f7ba7e51283ba8b1
+#### Property: (Blank Node)
 
-**Path:** ^http://www.w3.org/1999/02/22-rdf-syntax-ns#type
+**Path:** ^`rdf:type`
 
 **Constraints:**
-- **sh:minCount:** 1
-- **sh:maxCount:** 1
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:maxCount:** "1"^^xsd:integer
 
 ---
 
-## Shape: https://w3id.org/riverbench/schema/dataset-shacl#CategoryShape
+## Shape: TaskShape
 
 ### NodeShape Constraints
 
-- **sh:targetNode:** https://w3id.org/riverbench/temp#category
+- **sh:targetNode:** `ns1:task`
 
 ### Properties
 
-#### Property: nd704ac798dc3413691f7ba7e51283ba8b3
+#### Property: (Blank Node)
 
-**Path:** http://www.w3.org/1999/02/22-rdf-syntax-ns#type
-
-**Constraints:**
-- **sh:minCount:** 1
-- **sh:maxCount:** 1
-- **sh:hasValue:** https://w3id.org/riverbench/schema/metadata#Category
-
-#### Property: nd704ac798dc3413691f7ba7e51283ba8b4
-
-**Path:** http://purl.org/dc/terms/conformsTo
+**Path:** `rdf:type`
 
 **Constraints:**
-- **sh:minCount:** 1
-- **sh:maxCount:** 1
-- **sh:hasValue:** https://w3id.org/riverbench/schema/metadata
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:maxCount:** "1"^^xsd:integer
+- **sh:hasValue:** `rb:Task`
 
-#### Property: nd704ac798dc3413691f7ba7e51283ba8b5
+#### Property: (Blank Node)
 
-**Path:** http://purl.org/dc/terms/identifier
-
-**Constraints:**
-- **sh:minCount:** 1
-- **sh:maxCount:** 1
-- **sh:datatype:** http://www.w3.org/2001/XMLSchema#string
-
-#### Property: nd704ac798dc3413691f7ba7e51283ba8b6
-
-**Path:** http://purl.org/dc/terms/title
+**Path:** `dcterms:conformsTo`
 
 **Constraints:**
-- **sh:minCount:** 1
-- **sh:datatype:** http://www.w3.org/1999/02/22-rdf-syntax-ns#langString
-- **sh:uniqueLang:** true
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:maxCount:** "1"^^xsd:integer
+- **sh:hasValue:** `ns2:metadata`
 
-#### Property: nd704ac798dc3413691f7ba7e51283ba8b7
+#### Property: (Blank Node)
 
-**Path:** http://purl.org/dc/terms/description
+**Path:** `dcterms:identifier`
 
 **Constraints:**
-- **sh:minCount:** 1
-- **sh:datatype:** http://www.w3.org/1999/02/22-rdf-syntax-ns#langString
-- **sh:uniqueLang:** true
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:maxCount:** "1"^^xsd:integer
+- **sh:datatype:** `xsd:string`
+
+#### Property: (Blank Node)
+
+**Path:** `dcterms:title`
+
+**Constraints:**
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:datatype:** `rdf:langString`
+- **sh:uniqueLang:** "True"^^xsd:boolean
+
+#### Property: (Blank Node)
+
+**Path:** `dcterms:description`
+
+**Constraints:**
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:datatype:** `rdf:langString`
+- **sh:uniqueLang:** "True"^^xsd:boolean
+
+#### Property: (Blank Node)
+
+**Path:** `dcterms:creator`
+
+**Constraints:**
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:nodeKind:** `sh:BlankNodeOrIRI`
 
 ---
 
-## Shape: https://w3id.org/riverbench/schema/dataset-shacl#DatasetGraphShape
+## Shape: CategoryGraphShape
 
 ### NodeShape Constraints
 
-- **sh:targetNode:** https://w3id.org/riverbench/schema/metadata#Dataset
+- **sh:targetNode:** `rb:Category`
 
 ### Properties
 
-#### Property: n4fead01b140144af86da1873f016e0c4b1
+#### Property: (Blank Node)
 
-**Path:** ^http://www.w3.org/1999/02/22-rdf-syntax-ns#type
+**Path:** ^`rdf:type`
 
 **Constraints:**
-- **sh:minCount:** 1
-- **sh:maxCount:** 1
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:maxCount:** "1"^^xsd:integer
 
 ---
 
-## Shape: https://w3id.org/riverbench/schema/dataset-shacl#DatasetShape
+## Shape: CategoryShape
 
 ### NodeShape Constraints
 
-- **sh:targetClass:** https://w3id.org/riverbench/schema/metadata#Dataset
+- **sh:targetNode:** `ns1:category`
 
 ### Properties
 
-#### Property: n4fead01b140144af86da1873f016e0c4b3
+#### Property: (Blank Node)
 
-**Path:** http://www.w3.org/1999/02/22-rdf-syntax-ns#type
-
-**Constraints:**
-- **sh:minCount:** 1
-- **sh:hasValue:** http://www.w3.org/ns/dcat#Dataset
-
-#### Property: n4fead01b140144af86da1873f016e0c4b4
-
-**Path:** http://purl.org/dc/terms/conformsTo
+**Path:** `rdf:type`
 
 **Constraints:**
-- **sh:minCount:** 1
-- **sh:maxCount:** 1
-- **sh:nodeKind:** http://www.w3.org/ns/shacl#IRI
-- **sh:hasValue:** https://w3id.org/riverbench/schema/metadata
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:maxCount:** "1"^^xsd:integer
+- **sh:hasValue:** `rb:Category`
 
-#### Property: n4fead01b140144af86da1873f016e0c4b5
+#### Property: (Blank Node)
 
-**Path:** http://purl.org/dc/terms/identifier
-
-**Constraints:**
-- **sh:minCount:** 1
-- **sh:maxCount:** 1
-- **sh:datatype:** http://www.w3.org/2001/XMLSchema#string
-
-#### Property: n4fead01b140144af86da1873f016e0c4b6
-
-**Path:** http://purl.org/dc/terms/title
+**Path:** `dcterms:conformsTo`
 
 **Constraints:**
-- **sh:minCount:** 1
-- **sh:datatype:** http://www.w3.org/1999/02/22-rdf-syntax-ns#langString
-- **sh:uniqueLang:** true
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:maxCount:** "1"^^xsd:integer
+- **sh:hasValue:** `ns2:metadata`
 
-#### Property: n4fead01b140144af86da1873f016e0c4b7
+#### Property: (Blank Node)
 
-**Path:** http://purl.org/dc/terms/description
-
-**Constraints:**
-- **sh:minCount:** 1
-- **sh:datatype:** http://www.w3.org/1999/02/22-rdf-syntax-ns#langString
-- **sh:uniqueLang:** true
-
-#### Property: n4fead01b140144af86da1873f016e0c4b8
-
-**Path:** http://purl.org/dc/terms/issued
+**Path:** `dcterms:identifier`
 
 **Constraints:**
-- **sh:minCount:** 1
-- **sh:maxCount:** 1
-- **sh:datatype:** http://www.w3.org/2001/XMLSchema#date
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:maxCount:** "1"^^xsd:integer
+- **sh:datatype:** `xsd:string`
 
-#### Property: n4fead01b140144af86da1873f016e0c4b9
+#### Property: (Blank Node)
 
-**Path:** http://purl.org/dc/terms/license
-
-**Constraints:**
-- **sh:minCount:** 1
-- **sh:maxCount:** 1
-- **sh:nodeKind:** http://www.w3.org/ns/shacl#IRI
-- **sh:pattern:** ^https://spdx.org/licenses/
-
-#### Property: n4fead01b140144af86da1873f016e0c4b10
-
-**Path:** http://purl.org/dc/terms/creator
+**Path:** `dcterms:title`
 
 **Constraints:**
-- **sh:minCount:** 1
-- **sh:nodeKind:** http://www.w3.org/ns/shacl#BlankNodeOrIRI
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:datatype:** `rdf:langString`
+- **sh:uniqueLang:** "True"^^xsd:boolean
 
-#### Property: n4fead01b140144af86da1873f016e0c4b11
+#### Property: (Blank Node)
 
-**Path:** http://www.w3.org/ns/dcat#theme
-
-**Constraints:**
-- **sh:minCount:** 1
-- **sh:nodeKind:** http://www.w3.org/ns/shacl#IRI
-- **sh:pattern:** ^http://eurovoc.europa.eu/
-- **sh:node:** {'sh:property': rdflib.term.BNode('n4fead01b140144af86da1873f016e0c4b13')}
-
-#### Property: n4fead01b140144af86da1873f016e0c4b14
-
-**Path:** http://rdfs.org/ns/void#vocabulary
+**Path:** `dcterms:description`
 
 **Constraints:**
-- **sh:minCount:** 1
-- **sh:nodeKind:** http://www.w3.org/ns/shacl#IRI
-
-#### Property: n4fead01b140144af86da1873f016e0c4b15
-
-**Path:** https://w3id.org/riverbench/schema/metadata#hasStreamElementCount
-
-**Constraints:**
-- **sh:minCount:** 1
-- **sh:maxCount:** 1
-- **sh:datatype:** http://www.w3.org/2001/XMLSchema#integer
-
-#### Property: n4fead01b140144af86da1873f016e0c4b16
-
-**Path:** https://w3id.org/stax/ontology#hasStreamTypeUsage
-
-**Constraints:**
-- **sh:minCount:** 1
-- **sh:maxCount:** 2
-- **sh:node:** https://w3id.org/riverbench/schema/dataset-shacl#StreamTypeShape
-
-#### Property: n4fead01b140144af86da1873f016e0c4b17
-
-**Path:** https://w3id.org/riverbench/schema/metadata#hasStreamElementSplit
-
-**Constraints:**
-- **sh:nodeKind:** http://www.w3.org/ns/shacl#BlankNodeOrIRI
-- **sh:node:** https://w3id.org/riverbench/schema/dataset-shacl#StreamElementSplitShape
-
-#### Property: n4fead01b140144af86da1873f016e0c4b18
-
-**Path:** https://w3id.org/riverbench/schema/metadata#conformsToRdf11
-
-**Constraints:**
-- **sh:minCount:** 1
-- **sh:maxCount:** 1
-- **sh:datatype:** http://www.w3.org/2001/XMLSchema#boolean
-
-#### Property: n4fead01b140144af86da1873f016e0c4b19
-
-**Path:** https://w3id.org/riverbench/schema/metadata#conformsToRdfStarDraft_20211217
-
-**Constraints:**
-- **sh:minCount:** 1
-- **sh:maxCount:** 1
-- **sh:datatype:** http://www.w3.org/2001/XMLSchema#boolean
-
-#### Property: n4fead01b140144af86da1873f016e0c4b20
-
-**Path:** https://w3id.org/riverbench/schema/metadata#usesGeneralizedRdfDatasets
-
-**Constraints:**
-- **sh:minCount:** 1
-- **sh:maxCount:** 1
-- **sh:datatype:** http://www.w3.org/2001/XMLSchema#boolean
-
-#### Property: n4fead01b140144af86da1873f016e0c4b21
-
-**Path:** https://w3id.org/riverbench/schema/metadata#usesGeneralizedTriples
-
-**Constraints:**
-- **sh:minCount:** 1
-- **sh:maxCount:** 1
-- **sh:datatype:** http://www.w3.org/2001/XMLSchema#boolean
-
-#### Property: n4fead01b140144af86da1873f016e0c4b22
-
-**Path:** https://w3id.org/riverbench/schema/metadata#usesRdfStar
-
-**Constraints:**
-- **sh:minCount:** 1
-- **sh:maxCount:** 1
-- **sh:datatype:** http://www.w3.org/2001/XMLSchema#boolean
-
-#### Property: n4fead01b140144af86da1873f016e0c4b23
-
-**Path:** http://www.w3.org/ns/dcat#version
-
-**Constraints:**
-- **sh:maxCount:** 0
-
-#### Property: n4fead01b140144af86da1873f016e0c4b24
-
-**Path:** http://purl.org/dc/terms/modified
-
-**Constraints:**
-- **sh:maxCount:** 0
-
-#### Property: n4fead01b140144af86da1873f016e0c4b25
-
-**Path:** http://www.w3.org/ns/dcat#landingPage
-
-**Constraints:**
-- **sh:maxCount:** 0
-
-#### Property: n4fead01b140144af86da1873f016e0c4b26
-
-**Path:** http://www.w3.org/ns/dcat#inSeries
-
-**Constraints:**
-- **sh:maxCount:** 0
-
-#### Property: n4fead01b140144af86da1873f016e0c4b27
-
-**Path:** http://www.w3.org/ns/dcat#distribution
-
-**Constraints:**
-- **sh:maxCount:** 0
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:datatype:** `rdf:langString`
+- **sh:uniqueLang:** "True"^^xsd:boolean
 
 ---
 
-## Shape: https://w3id.org/riverbench/schema/dataset-shacl#StreamTypeShape
+## Shape: DatasetGraphShape
 
 ### NodeShape Constraints
 
-- **sh:and:** {}
-
----
-
-## Shape: n4fead01b140144af86da1873f016e0c4b31
+- **sh:targetNode:** `rb:Dataset`
 
 ### Properties
 
-#### Property: n4fead01b140144af86da1873f016e0c4b32
+#### Property: (Blank Node)
 
-**Path:** http://www.w3.org/1999/02/22-rdf-syntax-ns#type
+**Path:** ^`rdf:type`
 
 **Constraints:**
-- **sh:hasValue:** https://w3id.org/stax/ontology#ConcreteRdfStreamType
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:maxCount:** "1"^^xsd:integer
 
 ---
 
-## Shape: https://w3id.org/riverbench/schema/dataset-shacl#FlatStreamTypeShape
+## Shape: DatasetShape
 
 ### NodeShape Constraints
 
-- **sh:targetNode:** https://w3id.org/stax/ontology#flatStream
+- **sh:targetClass:** `rb:Dataset`
 
 ### Properties
 
-#### Property: n4fead01b140144af86da1873f016e0c4b53
+#### Property: (Blank Node)
 
-**Path:** ((http://www.w3.org/2004/02/skos/core#narrower)+)/(^https://w3id.org/stax/ontology#hasStreamType)/(^https://w3id.org/stax/ontology#hasStreamTypeUsage)
+**Path:** `rdf:type`
 
 **Constraints:**
-- **sh:minCount:** 1
-- **sh:maxCount:** 1
-- **sh:nodeKind:** http://www.w3.org/ns/shacl#IRI
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:hasValue:** `dcat:Dataset`
+
+#### Property: (Blank Node)
+
+**Path:** `dcterms:conformsTo`
+
+**Constraints:**
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:maxCount:** "1"^^xsd:integer
+- **sh:nodeKind:** `sh:IRI`
+- **sh:hasValue:** `ns1:metadata`
+
+#### Property: (Blank Node)
+
+**Path:** `dcterms:identifier`
+
+**Constraints:**
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:maxCount:** "1"^^xsd:integer
+- **sh:datatype:** `xsd:string`
+
+#### Property: (Blank Node)
+
+**Path:** `dcterms:title`
+
+**Constraints:**
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:datatype:** `rdf:langString`
+- **sh:uniqueLang:** "True"^^xsd:boolean
+
+#### Property: (Blank Node)
+
+**Path:** `dcterms:description`
+
+**Constraints:**
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:datatype:** `rdf:langString`
+- **sh:uniqueLang:** "True"^^xsd:boolean
+
+#### Property: (Blank Node)
+
+**Path:** `dcterms:issued`
+
+**Constraints:**
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:maxCount:** "1"^^xsd:integer
+- **sh:datatype:** `xsd:date`
+
+#### Property: (Blank Node)
+
+**Path:** `dcterms:license`
+
+**Constraints:**
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:maxCount:** "1"^^xsd:integer
+- **sh:nodeKind:** `sh:IRI`
+- **sh:pattern:** "^https://spdx.org/licenses/"
+
+#### Property: (Blank Node)
+
+**Path:** `dcterms:creator`
+
+**Constraints:**
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:nodeKind:** `sh:BlankNodeOrIRI`
+
+#### Property: (Blank Node)
+
+**Path:** `dcat:theme`
+
+**Constraints:**
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:nodeKind:** `sh:IRI`
+- **sh:pattern:** "^http://eurovoc.europa.eu/"
+- **sh:node:** (Blank Node)
+
+#### Property: (Blank Node)
+
+**Path:** `void:vocabulary`
+
+**Constraints:**
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:nodeKind:** `sh:IRI`
+
+#### Property: (Blank Node)
+
+**Path:** `rb:hasStreamElementCount`
+
+**Constraints:**
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:maxCount:** "1"^^xsd:integer
+- **sh:datatype:** `xsd:integer`
+
+#### Property: (Blank Node)
+
+**Path:** `stax:hasStreamTypeUsage`
+
+**Constraints:**
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:maxCount:** "2"^^xsd:integer
+- **sh:node:** `StreamTypeShape`
+
+#### Property: (Blank Node)
+
+**Path:** `rb:hasStreamElementSplit`
+
+**Constraints:**
+- **sh:nodeKind:** `sh:BlankNodeOrIRI`
+- **sh:node:** `StreamElementSplitShape`
+
+#### Property: (Blank Node)
+
+**Path:** `rb:conformsToRdf11`
+
+**Constraints:**
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:maxCount:** "1"^^xsd:integer
+- **sh:datatype:** `xsd:boolean`
+
+#### Property: (Blank Node)
+
+**Path:** `rb:conformsToRdfStarDraft_20211217`
+
+**Constraints:**
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:maxCount:** "1"^^xsd:integer
+- **sh:datatype:** `xsd:boolean`
+
+#### Property: (Blank Node)
+
+**Path:** `rb:usesGeneralizedRdfDatasets`
+
+**Constraints:**
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:maxCount:** "1"^^xsd:integer
+- **sh:datatype:** `xsd:boolean`
+
+#### Property: (Blank Node)
+
+**Path:** `rb:usesGeneralizedTriples`
+
+**Constraints:**
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:maxCount:** "1"^^xsd:integer
+- **sh:datatype:** `xsd:boolean`
+
+#### Property: (Blank Node)
+
+**Path:** `rb:usesRdfStar`
+
+**Constraints:**
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:maxCount:** "1"^^xsd:integer
+- **sh:datatype:** `xsd:boolean`
+
+#### Property: (Blank Node)
+
+**Path:** `dcat:version`
+
+**Constraints:**
+- **sh:maxCount:** "0"^^xsd:integer
+
+#### Property: (Blank Node)
+
+**Path:** `dcterms:modified`
+
+**Constraints:**
+- **sh:maxCount:** "0"^^xsd:integer
+
+#### Property: (Blank Node)
+
+**Path:** `dcat:landingPage`
+
+**Constraints:**
+- **sh:maxCount:** "0"^^xsd:integer
+
+#### Property: (Blank Node)
+
+**Path:** `dcat:inSeries`
+
+**Constraints:**
+- **sh:maxCount:** "0"^^xsd:integer
+
+#### Property: (Blank Node)
+
+**Path:** `dcat:distribution`
+
+**Constraints:**
+- **sh:maxCount:** "0"^^xsd:integer
 
 ---
 
-## Shape: https://w3id.org/riverbench/schema/dataset-shacl#StreamElementSplitShape
-
-### Properties
-
-#### Property: n4fead01b140144af86da1873f016e0c4b60
-
-**Path:** http://www.w3.org/1999/02/22-rdf-syntax-ns#type
-
-**Constraints:**
-- **sh:in:** {}
-
----
-
-## Shape: https://w3id.org/riverbench/schema/dataset-shacl#SubjectShapeShape
+## Shape: StreamTypeShape
 
 ### NodeShape Constraints
 
-- **sh:targetSubjectsOf:** https://w3id.org/riverbench/schema/metadata#hasSubjectShape
-
-### Properties
-
-#### Property: n4fead01b140144af86da1873f016e0c4b64
-
-**Path:** http://www.w3.org/1999/02/22-rdf-syntax-ns#type
-
-**Constraints:**
-- **sh:minCount:** 1
-- **sh:hasValue:** https://w3id.org/riverbench/schema/metadata#TopicStreamElementSplit
-
-#### Property: n4fead01b140144af86da1873f016e0c4b65
-
-**Path:** https://w3id.org/riverbench/schema/metadata#hasSubjectShape/(http://www.w3.org/ns/shacl#targetClass|http://www.w3.org/ns/shacl#targetSubjectsOf|http://www.w3.org/ns/shacl#targetObjectsOf|https://w3id.org/riverbench/schema/metadata#targetCustom)
-
-**Constraints:**
-- **sh:minCount:** 1
-- **sh:nodeKind:** http://www.w3.org/ns/shacl#IRI
+- **sh:and:** (Blank Node)
 
 ---
 
-## Shape: https://w3id.org/riverbench/schema/dataset-shacl#TaskGraphShape
-
-### NodeShape Constraints
-
-- **sh:targetNode:** https://w3id.org/riverbench/schema/metadata#Task
+## Shape: (Blank Node)
 
 ### Properties
 
-#### Property: n6a1b63e6b8cc4767a105c234ac65a447b1
+#### Property: (Blank Node)
 
-**Path:** ^http://www.w3.org/1999/02/22-rdf-syntax-ns#type
+**Path:** `rdf:type`
 
 **Constraints:**
-- **sh:minCount:** 1
-- **sh:maxCount:** 1
+- **sh:hasValue:** `stax:ConcreteRdfStreamType`
 
 ---
 
-## Shape: https://w3id.org/riverbench/schema/dataset-shacl#TaskShape
+## Shape: FlatStreamTypeShape
 
 ### NodeShape Constraints
 
-- **sh:targetNode:** https://w3id.org/riverbench/temp#task
+- **sh:targetNode:** `stax:flatStream`
 
 ### Properties
 
-#### Property: n6a1b63e6b8cc4767a105c234ac65a447b3
+#### Property: (Blank Node)
 
-**Path:** http://www.w3.org/1999/02/22-rdf-syntax-ns#type
-
-**Constraints:**
-- **sh:minCount:** 1
-- **sh:maxCount:** 1
-- **sh:hasValue:** https://w3id.org/riverbench/schema/metadata#Task
-
-#### Property: n6a1b63e6b8cc4767a105c234ac65a447b4
-
-**Path:** http://purl.org/dc/terms/conformsTo
+**Path:** ((`skos:narrower`)+)/(^`stax:hasStreamType`)/(^`stax:hasStreamTypeUsage`)
 
 **Constraints:**
-- **sh:minCount:** 1
-- **sh:maxCount:** 1
-- **sh:hasValue:** https://w3id.org/riverbench/schema/metadata
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:maxCount:** "1"^^xsd:integer
+- **sh:nodeKind:** `sh:IRI`
 
-#### Property: n6a1b63e6b8cc4767a105c234ac65a447b5
+---
 
-**Path:** http://purl.org/dc/terms/identifier
+## Shape: StreamElementSplitShape
 
-**Constraints:**
-- **sh:minCount:** 1
-- **sh:maxCount:** 1
-- **sh:datatype:** http://www.w3.org/2001/XMLSchema#string
+### Properties
 
-#### Property: n6a1b63e6b8cc4767a105c234ac65a447b6
+#### Property: (Blank Node)
 
-**Path:** http://purl.org/dc/terms/title
+**Path:** `rdf:type`
 
 **Constraints:**
-- **sh:minCount:** 1
-- **sh:datatype:** http://www.w3.org/1999/02/22-rdf-syntax-ns#langString
-- **sh:uniqueLang:** true
+- **sh:in:** (Blank Node)
 
-#### Property: n6a1b63e6b8cc4767a105c234ac65a447b7
+---
 
-**Path:** http://purl.org/dc/terms/description
+## Shape: SubjectShapeShape
+
+### NodeShape Constraints
+
+- **sh:targetSubjectsOf:** `rb:hasSubjectShape`
+
+### Properties
+
+#### Property: (Blank Node)
+
+**Path:** `rdf:type`
 
 **Constraints:**
-- **sh:minCount:** 1
-- **sh:datatype:** http://www.w3.org/1999/02/22-rdf-syntax-ns#langString
-- **sh:uniqueLang:** true
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:hasValue:** `rb:TopicStreamElementSplit`
 
-#### Property: n6a1b63e6b8cc4767a105c234ac65a447b8
+#### Property: (Blank Node)
 
-**Path:** http://purl.org/dc/terms/creator
+**Path:** `rb:hasSubjectShape`/(`sh:targetClass`|`sh:targetSubjectsOf`|`sh:targetObjectsOf`|`rb:targetCustom`)
 
 **Constraints:**
-- **sh:minCount:** 1
-- **sh:nodeKind:** http://www.w3.org/ns/shacl#BlankNodeOrIRI
+- **sh:minCount:** "1"^^xsd:integer
+- **sh:nodeKind:** `sh:IRI`
 
 ---
 

--- a/docs/shapes.md
+++ b/docs/shapes.md
@@ -10,7 +10,13 @@
 
 #### Property: (Blank Node)
 
-**Path:** ^`rdf:type`
+**Path:**
+
+- Inverse of:
+  - Predicate path:
+    - `rdf:type`
+
+^`rdf:type`
 
 **Constraints:**
 - **sh:minCount:** "1"^^xsd:integer
@@ -28,7 +34,12 @@
 
 #### Property: (Blank Node)
 
-**Path:** `rdf:type`
+**Path:**
+
+- Predicate path:
+  - `rdf:type`
+
+`rdf:type`
 
 **Constraints:**
 - **sh:minCount:** "1"^^xsd:integer
@@ -36,7 +47,12 @@
 
 #### Property: (Blank Node)
 
-**Path:** `dcterms:identifier`
+**Path:**
+
+- Predicate path:
+  - `dcterms:identifier`
+
+`dcterms:identifier`
 
 **Constraints:**
 - **sh:minCount:** "1"^^xsd:integer
@@ -45,7 +61,12 @@
 
 #### Property: (Blank Node)
 
-**Path:** `dcterms:title`
+**Path:**
+
+- Predicate path:
+  - `dcterms:title`
+
+`dcterms:title`
 
 **Constraints:**
 - **sh:minCount:** "1"^^xsd:integer
@@ -54,7 +75,12 @@
 
 #### Property: (Blank Node)
 
-**Path:** `dcterms:description`
+**Path:**
+
+- Predicate path:
+  - `dcterms:description`
+
+`dcterms:description`
 
 **Constraints:**
 - **sh:minCount:** "1"^^xsd:integer
@@ -63,7 +89,12 @@
 
 #### Property: (Blank Node)
 
-**Path:** `rb:hasDatasetShape`
+**Path:**
+
+- Predicate path:
+  - `rb:hasDatasetShape`
+
+`rb:hasDatasetShape`
 
 **Constraints:**
 - **sh:minCount:** "1"^^xsd:integer
@@ -72,7 +103,12 @@
 
 #### Property: (Blank Node)
 
-**Path:** `rb:hasDistributionShape`
+**Path:**
+
+- Predicate path:
+  - `rb:hasDistributionShape`
+
+`rb:hasDistributionShape`
 
 **Constraints:**
 - **sh:minCount:** "1"^^xsd:integer
@@ -91,7 +127,13 @@
 
 #### Property: (Blank Node)
 
-**Path:** ^`rdf:type`
+**Path:**
+
+- Inverse of:
+  - Predicate path:
+    - `rdf:type`
+
+^`rdf:type`
 
 **Constraints:**
 - **sh:minCount:** "1"^^xsd:integer
@@ -109,7 +151,12 @@
 
 #### Property: (Blank Node)
 
-**Path:** `rdf:type`
+**Path:**
+
+- Predicate path:
+  - `rdf:type`
+
+`rdf:type`
 
 **Constraints:**
 - **sh:minCount:** "1"^^xsd:integer
@@ -118,7 +165,12 @@
 
 #### Property: (Blank Node)
 
-**Path:** `dcterms:conformsTo`
+**Path:**
+
+- Predicate path:
+  - `dcterms:conformsTo`
+
+`dcterms:conformsTo`
 
 **Constraints:**
 - **sh:minCount:** "1"^^xsd:integer
@@ -127,7 +179,12 @@
 
 #### Property: (Blank Node)
 
-**Path:** `dcterms:identifier`
+**Path:**
+
+- Predicate path:
+  - `dcterms:identifier`
+
+`dcterms:identifier`
 
 **Constraints:**
 - **sh:minCount:** "1"^^xsd:integer
@@ -136,7 +193,12 @@
 
 #### Property: (Blank Node)
 
-**Path:** `dcterms:title`
+**Path:**
+
+- Predicate path:
+  - `dcterms:title`
+
+`dcterms:title`
 
 **Constraints:**
 - **sh:minCount:** "1"^^xsd:integer
@@ -145,7 +207,12 @@
 
 #### Property: (Blank Node)
 
-**Path:** `dcterms:description`
+**Path:**
+
+- Predicate path:
+  - `dcterms:description`
+
+`dcterms:description`
 
 **Constraints:**
 - **sh:minCount:** "1"^^xsd:integer
@@ -154,7 +221,12 @@
 
 #### Property: (Blank Node)
 
-**Path:** `dcterms:creator`
+**Path:**
+
+- Predicate path:
+  - `dcterms:creator`
+
+`dcterms:creator`
 
 **Constraints:**
 - **sh:minCount:** "1"^^xsd:integer
@@ -172,7 +244,13 @@
 
 #### Property: (Blank Node)
 
-**Path:** ^`rdf:type`
+**Path:**
+
+- Inverse of:
+  - Predicate path:
+    - `rdf:type`
+
+^`rdf:type`
 
 **Constraints:**
 - **sh:minCount:** "1"^^xsd:integer
@@ -190,7 +268,12 @@
 
 #### Property: (Blank Node)
 
-**Path:** `rdf:type`
+**Path:**
+
+- Predicate path:
+  - `rdf:type`
+
+`rdf:type`
 
 **Constraints:**
 - **sh:minCount:** "1"^^xsd:integer
@@ -199,7 +282,12 @@
 
 #### Property: (Blank Node)
 
-**Path:** `dcterms:conformsTo`
+**Path:**
+
+- Predicate path:
+  - `dcterms:conformsTo`
+
+`dcterms:conformsTo`
 
 **Constraints:**
 - **sh:minCount:** "1"^^xsd:integer
@@ -208,7 +296,12 @@
 
 #### Property: (Blank Node)
 
-**Path:** `dcterms:identifier`
+**Path:**
+
+- Predicate path:
+  - `dcterms:identifier`
+
+`dcterms:identifier`
 
 **Constraints:**
 - **sh:minCount:** "1"^^xsd:integer
@@ -217,7 +310,12 @@
 
 #### Property: (Blank Node)
 
-**Path:** `dcterms:title`
+**Path:**
+
+- Predicate path:
+  - `dcterms:title`
+
+`dcterms:title`
 
 **Constraints:**
 - **sh:minCount:** "1"^^xsd:integer
@@ -226,7 +324,12 @@
 
 #### Property: (Blank Node)
 
-**Path:** `dcterms:description`
+**Path:**
+
+- Predicate path:
+  - `dcterms:description`
+
+`dcterms:description`
 
 **Constraints:**
 - **sh:minCount:** "1"^^xsd:integer
@@ -245,7 +348,13 @@
 
 #### Property: (Blank Node)
 
-**Path:** ^`rdf:type`
+**Path:**
+
+- Inverse of:
+  - Predicate path:
+    - `rdf:type`
+
+^`rdf:type`
 
 **Constraints:**
 - **sh:minCount:** "1"^^xsd:integer
@@ -263,7 +372,12 @@
 
 #### Property: (Blank Node)
 
-**Path:** `rdf:type`
+**Path:**
+
+- Predicate path:
+  - `rdf:type`
+
+`rdf:type`
 
 **Constraints:**
 - **sh:minCount:** "1"^^xsd:integer
@@ -271,7 +385,12 @@
 
 #### Property: (Blank Node)
 
-**Path:** `dcterms:conformsTo`
+**Path:**
+
+- Predicate path:
+  - `dcterms:conformsTo`
+
+`dcterms:conformsTo`
 
 **Constraints:**
 - **sh:minCount:** "1"^^xsd:integer
@@ -281,7 +400,12 @@
 
 #### Property: (Blank Node)
 
-**Path:** `dcterms:identifier`
+**Path:**
+
+- Predicate path:
+  - `dcterms:identifier`
+
+`dcterms:identifier`
 
 **Constraints:**
 - **sh:minCount:** "1"^^xsd:integer
@@ -290,7 +414,12 @@
 
 #### Property: (Blank Node)
 
-**Path:** `dcterms:title`
+**Path:**
+
+- Predicate path:
+  - `dcterms:title`
+
+`dcterms:title`
 
 **Constraints:**
 - **sh:minCount:** "1"^^xsd:integer
@@ -299,7 +428,12 @@
 
 #### Property: (Blank Node)
 
-**Path:** `dcterms:description`
+**Path:**
+
+- Predicate path:
+  - `dcterms:description`
+
+`dcterms:description`
 
 **Constraints:**
 - **sh:minCount:** "1"^^xsd:integer
@@ -308,7 +442,12 @@
 
 #### Property: (Blank Node)
 
-**Path:** `dcterms:issued`
+**Path:**
+
+- Predicate path:
+  - `dcterms:issued`
+
+`dcterms:issued`
 
 **Constraints:**
 - **sh:minCount:** "1"^^xsd:integer
@@ -317,7 +456,12 @@
 
 #### Property: (Blank Node)
 
-**Path:** `dcterms:license`
+**Path:**
+
+- Predicate path:
+  - `dcterms:license`
+
+`dcterms:license`
 
 **Constraints:**
 - **sh:minCount:** "1"^^xsd:integer
@@ -327,7 +471,12 @@
 
 #### Property: (Blank Node)
 
-**Path:** `dcterms:creator`
+**Path:**
+
+- Predicate path:
+  - `dcterms:creator`
+
+`dcterms:creator`
 
 **Constraints:**
 - **sh:minCount:** "1"^^xsd:integer
@@ -335,7 +484,12 @@
 
 #### Property: (Blank Node)
 
-**Path:** `dcat:theme`
+**Path:**
+
+- Predicate path:
+  - `dcat:theme`
+
+`dcat:theme`
 
 **Constraints:**
 - **sh:minCount:** "1"^^xsd:integer
@@ -345,7 +499,12 @@
 
 #### Property: (Blank Node)
 
-**Path:** `void:vocabulary`
+**Path:**
+
+- Predicate path:
+  - `void:vocabulary`
+
+`void:vocabulary`
 
 **Constraints:**
 - **sh:minCount:** "1"^^xsd:integer
@@ -353,7 +512,12 @@
 
 #### Property: (Blank Node)
 
-**Path:** `rb:hasStreamElementCount`
+**Path:**
+
+- Predicate path:
+  - `rb:hasStreamElementCount`
+
+`rb:hasStreamElementCount`
 
 **Constraints:**
 - **sh:minCount:** "1"^^xsd:integer
@@ -362,7 +526,12 @@
 
 #### Property: (Blank Node)
 
-**Path:** `stax:hasStreamTypeUsage`
+**Path:**
+
+- Predicate path:
+  - `stax:hasStreamTypeUsage`
+
+`stax:hasStreamTypeUsage`
 
 **Constraints:**
 - **sh:minCount:** "1"^^xsd:integer
@@ -371,7 +540,12 @@
 
 #### Property: (Blank Node)
 
-**Path:** `rb:hasStreamElementSplit`
+**Path:**
+
+- Predicate path:
+  - `rb:hasStreamElementSplit`
+
+`rb:hasStreamElementSplit`
 
 **Constraints:**
 - **sh:nodeKind:** `sh:BlankNodeOrIRI`
@@ -379,7 +553,12 @@
 
 #### Property: (Blank Node)
 
-**Path:** `rb:conformsToRdf11`
+**Path:**
+
+- Predicate path:
+  - `rb:conformsToRdf11`
+
+`rb:conformsToRdf11`
 
 **Constraints:**
 - **sh:minCount:** "1"^^xsd:integer
@@ -388,7 +567,12 @@
 
 #### Property: (Blank Node)
 
-**Path:** `rb:conformsToRdfStarDraft_20211217`
+**Path:**
+
+- Predicate path:
+  - `rb:conformsToRdfStarDraft_20211217`
+
+`rb:conformsToRdfStarDraft_20211217`
 
 **Constraints:**
 - **sh:minCount:** "1"^^xsd:integer
@@ -397,7 +581,12 @@
 
 #### Property: (Blank Node)
 
-**Path:** `rb:usesGeneralizedRdfDatasets`
+**Path:**
+
+- Predicate path:
+  - `rb:usesGeneralizedRdfDatasets`
+
+`rb:usesGeneralizedRdfDatasets`
 
 **Constraints:**
 - **sh:minCount:** "1"^^xsd:integer
@@ -406,7 +595,12 @@
 
 #### Property: (Blank Node)
 
-**Path:** `rb:usesGeneralizedTriples`
+**Path:**
+
+- Predicate path:
+  - `rb:usesGeneralizedTriples`
+
+`rb:usesGeneralizedTriples`
 
 **Constraints:**
 - **sh:minCount:** "1"^^xsd:integer
@@ -415,7 +609,12 @@
 
 #### Property: (Blank Node)
 
-**Path:** `rb:usesRdfStar`
+**Path:**
+
+- Predicate path:
+  - `rb:usesRdfStar`
+
+`rb:usesRdfStar`
 
 **Constraints:**
 - **sh:minCount:** "1"^^xsd:integer
@@ -424,35 +623,60 @@
 
 #### Property: (Blank Node)
 
-**Path:** `dcat:version`
+**Path:**
+
+- Predicate path:
+  - `dcat:version`
+
+`dcat:version`
 
 **Constraints:**
 - **sh:maxCount:** "0"^^xsd:integer
 
 #### Property: (Blank Node)
 
-**Path:** `dcterms:modified`
+**Path:**
+
+- Predicate path:
+  - `dcterms:modified`
+
+`dcterms:modified`
 
 **Constraints:**
 - **sh:maxCount:** "0"^^xsd:integer
 
 #### Property: (Blank Node)
 
-**Path:** `dcat:landingPage`
+**Path:**
+
+- Predicate path:
+  - `dcat:landingPage`
+
+`dcat:landingPage`
 
 **Constraints:**
 - **sh:maxCount:** "0"^^xsd:integer
 
 #### Property: (Blank Node)
 
-**Path:** `dcat:inSeries`
+**Path:**
+
+- Predicate path:
+  - `dcat:inSeries`
+
+`dcat:inSeries`
 
 **Constraints:**
 - **sh:maxCount:** "0"^^xsd:integer
 
 #### Property: (Blank Node)
 
-**Path:** `dcat:distribution`
+**Path:**
+
+- Predicate path:
+  - `dcat:distribution`
+
+`dcat:distribution`
 
 **Constraints:**
 - **sh:maxCount:** "0"^^xsd:integer
@@ -473,7 +697,12 @@
 
 #### Property: (Blank Node)
 
-**Path:** `rdf:type`
+**Path:**
+
+- Predicate path:
+  - `rdf:type`
+
+`rdf:type`
 
 **Constraints:**
 - **sh:hasValue:** `stax:ConcreteRdfStreamType`
@@ -490,7 +719,20 @@
 
 #### Property: (Blank Node)
 
-**Path:** ((`skos:narrower`)+)/(^`stax:hasStreamType`)/(^`stax:hasStreamTypeUsage`)
+**Path:**
+
+- Sequence of:
+  - One-or-more of:
+    - Predicate path:
+      - `skos:narrower`
+  - Inverse of:
+    - Predicate path:
+      - `stax:hasStreamType`
+  - Inverse of:
+    - Predicate path:
+      - `stax:hasStreamTypeUsage`
+
+((`skos:narrower`)+)/(^`stax:hasStreamType`)/(^`stax:hasStreamTypeUsage`)
 
 **Constraints:**
 - **sh:minCount:** "1"^^xsd:integer
@@ -505,7 +747,12 @@
 
 #### Property: (Blank Node)
 
-**Path:** `rdf:type`
+**Path:**
+
+- Predicate path:
+  - `rdf:type`
+
+`rdf:type`
 
 **Constraints:**
 - **sh:in:** (Blank Node)
@@ -522,7 +769,12 @@
 
 #### Property: (Blank Node)
 
-**Path:** `rdf:type`
+**Path:**
+
+- Predicate path:
+  - `rdf:type`
+
+`rdf:type`
 
 **Constraints:**
 - **sh:minCount:** "1"^^xsd:integer
@@ -530,7 +782,17 @@
 
 #### Property: (Blank Node)
 
-**Path:** `rb:hasSubjectShape`/(`sh:targetClass`|`sh:targetSubjectsOf`|`sh:targetObjectsOf`|`rb:targetCustom`)
+**Path:**
+
+- Sequence of:
+  - rb:hasSubjectShape
+  - Alternative of:
+    - sh:targetClass
+    - sh:targetSubjectsOf
+    - sh:targetObjectsOf
+    - rb:targetCustom
+
+`rb:hasSubjectShape`/(`sh:targetClass`|`sh:targetSubjectsOf`|`sh:targetObjectsOf`|`rb:targetCustom`)
 
 **Constraints:**
 - **sh:minCount:** "1"^^xsd:integer

--- a/main.py
+++ b/main.py
@@ -5,28 +5,71 @@ from shacl_doc_generator.generator import MarkdownGenerator
 
 def main():
     parser = argparse.ArgumentParser(description="SHACLER - SHACL Documentation Generator")
-    parser.add_argument("--input", required=True, help="Path to SHACL file or directory containing SHACL files.")
-    parser.add_argument("--output", required=False, default="./docs", help="Path to output directory for markdown files.")
+    parser.add_argument(
+        "--input",
+        required=True,
+        help="Path to SHACL file OR directory containing one or more *.ttl SHACL files."
+    )
+    parser.add_argument(
+        "--output",
+        required=False,
+        default="./docs",
+        help="Path to output directory for the generated .md files."
+    )
     args = parser.parse_args()
 
     input_path = Path(args.input)
     output_dir = Path(args.output)
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    shacl_parser = ShaclParser()
-    shapes_all = {}
+    md_generator = MarkdownGenerator()
 
     if input_path.is_dir():
-        for f in input_path.glob("*.ttl"):
-            shapes = shacl_parser.parse_file(f)
-            for k, v in shapes.items():
-                shapes_all[k] = v
-    else:
-        shapes_all = shacl_parser.parse_file(input_path)
+        ttl_files = list(input_path.glob("*.ttl"))
+        if not ttl_files:
+            print(f"No .ttl files found in {input_path}")
+            return
 
-    md_generator = MarkdownGenerator()
-    output_file = output_dir / 'shapes.md'
-    md_generator.generate_docs(shapes_all, output_file)
+        for ttl_file in ttl_files:
+            print(f"Processing file: {ttl_file}")
+
+            shacl_parser = ShaclParser()  # create a fresh parser
+            shapes_for_this_file = shacl_parser.parse_file(ttl_file)
+
+            output_file = output_dir / f"{ttl_file.stem}.md"
+            md_generator.generate_docs(shapes_for_this_file, output_filename=str(output_file))
+
+            with open(ttl_file, 'r', encoding='utf-8') as fp:
+                turtle_content = fp.read()
+
+            with open(output_file, 'a', encoding='utf-8') as out:
+                out.write("\n## Original SHACL File\n\n")
+                out.write("```turtle\n")
+                out.write(turtle_content)
+                out.write("\n```\n")
+
+    else:
+        if not input_path.is_file():
+            print(f"Error: {input_path} is not a file.")
+            return
+
+        print(f"Processing single file: {input_path}")
+
+        shacl_parser = ShaclParser()
+        shapes_for_this_file = shacl_parser.parse_file(input_path)
+
+        output_file = output_dir / f"{input_path.stem}.md"
+        md_generator.generate_docs(shapes_for_this_file, output_filename=str(output_file))
+
+        with open(input_path, 'r', encoding='utf-8') as fp:
+            turtle_content = fp.read()
+        with open(output_file, 'a', encoding='utf-8') as out:
+            out.write("\n## Original SHACL File\n\n")
+            out.write("```turtle\n")
+            out.write(turtle_content)
+            out.write("\n```\n")
+
 
 if __name__ == "__main__":
     main()
+

--- a/shacl_doc_generator/generator.py
+++ b/shacl_doc_generator/generator.py
@@ -67,9 +67,13 @@ class MarkdownGenerator:
             return "???"
 
     def _format_path_item(self, item):
-        """Format a single path item which can be either a string (predicate) or a Path."""
+        """
+        Format a single path item which can be either a string (prefixed IRI) 
+        or a Path. If it's a string, wrap it in backticks for Markdown.
+        """
         if isinstance(item, str):
-            return item
+            # Now item should already be "prefix:suffix".
+            return f"`{item}`"  # <--- wrap in backticks
         elif isinstance(item, Path):
             return f"({self._format_path(item)})"
         else:

--- a/shacl_doc_generator/models.py
+++ b/shacl_doc_generator/models.py
@@ -21,12 +21,6 @@ class Path:
     type: PathEnum
     items: List[Union["Path", str]]
 
-
-@dataclass
-class NodeShapeInfo:
-    id: str
-    constraints: List[Constraint] = field(default_factory=list)
-
 @dataclass
 class PropertyShapeInfo:
     id: str

--- a/shacl_doc_generator/parser.py
+++ b/shacl_doc_generator/parser.py
@@ -162,12 +162,9 @@ class ShaclParser:
         Parse a single path element, which can be a URIRef (predicate) or a complex BNode path.
         """
         if isinstance(element, URIRef):
-            # Convert full IRI to prefixed IRI
             try:
                 prefixed_name = g.namespace_manager.qname(element)
             except Exception as e:
-                # If something goes wrong or prefix isn’t known, fall back to the full IRI
-                print(f'prefix namespace manager failed: {e}')
                 prefixed_name = str(element)
             return prefixed_name
 

--- a/shacl_doc_generator/parser.py
+++ b/shacl_doc_generator/parser.py
@@ -19,7 +19,8 @@ class ShaclParser:
 
         for node in node_shapes:
             shape_info = self.extract_node_shape_info(g, node)
-            self.shapes[str(node)] = shape_info
+            prefixed = self.to_prefixed(g, node, False)
+            self.shapes[prefixed] = shape_info
 
         return self.shapes
 
@@ -40,7 +41,8 @@ class ShaclParser:
         for p, o in g.predicate_objects(node):
             if str(p).startswith(str(SH)) and p not in (SH.property, SH.path):
                 c_key = self._get_property_label(g, p)
-                c_val = self._extract_bnode_shape(g, o) if isinstance(o, BNode) else str(o)
+                # If o is a BNode or a URIRef, convert it
+                c_val = self.to_prefixed(g, o)
                 constraints.append(Constraint(name=c_key, value=c_val))
         return constraints
 
@@ -54,9 +56,10 @@ class ShaclParser:
     def extract_property_shape_info(self, g: Graph, pshape: URIRef) -> PropertyShapeInfo:
         path_node = g.value(pshape, SH.path)
         path = self._parse_path(g, path_node)
+        id_val = self.to_prefixed(g, pshape)
 
         return PropertyShapeInfo(
-            id=str(pshape),
+            id=id_val,
             path=path,
             constraints=self.extract_constraints(g, pshape)
         )
@@ -89,7 +92,8 @@ class ShaclParser:
     def _parse_path(self, g: Graph, node: Union[URIRef, BNode]) -> Path:
         """Parse a path node (URIRef or BNode) into a Path object."""
         if isinstance(node, URIRef):
-            return Path(type=PathEnum.predicate, items=[str(node)])
+            prefixed = self.to_prefixed(g, node)
+            return Path(type=PathEnum.predicate, items=[prefixed])
 
         # Check inversePath
         inverse = g.value(node, SH.inversePath)
@@ -154,10 +158,52 @@ class ShaclParser:
         return elements
 
     def _parse_path_element(self, g: Graph, element):
-        """Parse a single path element, which can be a URIRef (predicate) or a complex BNode path."""
+        """
+        Parse a single path element, which can be a URIRef (predicate) or a complex BNode path.
+        """
         if isinstance(element, URIRef):
-            return str(element)
+            # Convert full IRI to prefixed IRI
+            try:
+                prefixed_name = g.namespace_manager.qname(element)
+            except Exception as e:
+                # If something goes wrong or prefix isn’t known, fall back to the full IRI
+                print(f'prefix namespace manager failed: {e}')
+                prefixed_name = str(element)
+            return prefixed_name
+
         elif isinstance(element, BNode):
             return self._parse_path(g, element)
+
         else:
             raise ValueError(f"Path element {element} is neither URIRef nor BNode.")
+
+    def to_prefixed(self, g: Graph, term: Any, code_format: bool = True) -> str | int | float:
+        """
+        Convert a term (URIRef, BNode, or str) to a prefixed string if possible,
+        or a placeholder if it's a blank node/literal.
+        """
+
+        if isinstance(term, URIRef):
+            try:
+                # Attempt to convert to qname
+                qn = g.namespace_manager.qname(term)
+                return f"`{qn}`" if code_format else qn
+            except Exception:
+                # Fallback: just wrap the full URI in backticks
+                return f"`{str(term)}`" if code_format else str(term)
+        elif isinstance(term, BNode):
+            # Return a more user-friendly label
+            return "(Blank Node)"
+        elif isinstance(term, Literal):
+            if term.language:
+                # e.g. "Hello"@en
+                return f"\"{term.value}\"@{term.language}"
+            elif term.datatype:
+                # show typed
+                return f"\"{term.value}\"^^{g.namespace_manager.qname(term.datatype)}"
+            else:
+                # untyped literal
+                return f"\"{term.value}\""
+        else:
+            return f"`{term}`" if code_format else term
+


### PR DESCRIPTION
:heavy_check_mark:  - preserve suffixes from input file – unformatted IRI -> prefixed IRI
	- there should be a function in rdflib, if not implement it ourselves
	- additionally format IRI as a code fragment (enquote with ``)
:heavy_check_mark:  - display sparql paths as a bullet point tree
	- example:
		- Sequence of:
			- Alternative of:
				- property 1
				- property 2
				- property 3
			- Inverse of: 
				- property 4
:x: - use shacl labels instead of these with prefixes (e.g. sh:minCount -> "min count")
not done because rdfs labels were not accessible, consider hardcoding the labels? 
:heavy_check_mark:  - include the input file in the end of the file (with turtle specified for syntax highlighting)